### PR TITLE
arch/arm/stackusage: improve regex clarity with raw string literals

### DIFF
--- a/arch/arm/stackusage
+++ b/arch/arm/stackusage
@@ -3,11 +3,11 @@
 import sys
 import re
 
-hexrule = re.compile("([0-9a-fA-F]+)")
-hex2byterule = re.compile("([0-9a-fA-F]{4})")
-hexcolonrule = re.compile("([0-9a-fA-F]+):")
-symbolrule = re.compile("<([._a-zA-Z]+[._0-9a-zA-Z]*)>:")
-insrule = re.compile("([a-zA-Z][.a-zA-Z]*)")
+hexrule = re.compile(r"([0-9a-fA-F]+)")
+hex2byterule = re.compile(r"([0-9a-fA-F]{4})")
+hexcolonrule = re.compile(r"([0-9a-fA-F]+):")
+symbolrule = re.compile(r"<([._a-zA-Z]+[._0-9a-zA-Z]*)>:")
+insrule = re.compile(r"([a-zA-Z][.a-zA-Z]*)")
 
 currsymbol = ""
 curraddress = 0


### PR DESCRIPTION
This patch updates several regular expression definitions to use raw string literals (prefixed with r).

The previous standard string literals caused warning:
```
SyntaxWarning: invalid escape sequence '\:'
  hexcolonrule = re.compile("([0-9a-fA-F]+)\:")
```